### PR TITLE
List keywords on the left sidebar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  
+  @words = Keyword.all
 end

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -1,5 +1,8 @@
 class IdeasController < ApplicationController
-		before_action :set_idea, only: [:show, :edit, :update, :destroy]
+		
+    before_action :set_idea, only: [:show, :edit, :update, :destroy]
+    before_action :set_keywords
+    
 
 		# GET /ideas
 		# GET /ideas.json
@@ -11,6 +14,7 @@ class IdeasController < ApplicationController
 		# GET /ideas/1.json
 		def show
 				@keywords = Idea.find(params[:id]).keywords
+        @words = @keywords
 		end
 
 		# GET /ideas/new
@@ -75,6 +79,10 @@ class IdeasController < ApplicationController
 		def set_idea
 				@idea = Idea.find(params[:id])
 		end
+
+    def set_keywords
+        @words = Keyword.all
+    end
 
 		# Never trust parameters from the scary internet, only allow the white list through.
 		def idea_params

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -1,5 +1,6 @@
 class KeywordsController < ApplicationController
   before_action :set_keyword, only: [:show, :edit, :update, :destroy]
+  before_action :set_keywords
 
   # GET /keywords
   # GET /keywords.json
@@ -65,6 +66,10 @@ class KeywordsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_keyword
       @keyword = Keyword.find(params[:id])
+    end
+
+    def set_keywords
+      @words = Keyword.all
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -40,10 +40,9 @@
         .span3
           .well.sidebar-nav
             %ul.nav.nav-list
-              %li.nav-header Sidebar
-              %li= link_to "Link 1", "/path1"
-              %li= link_to "Link 2", "/path2"
-              %li= link_to "Link 3", "/path3"
+              %li.nav-header Keywords
+              - @words.each do |keyword|                                     
+                %li= link_to keyword.name, keyword_path(keyword)
         .span9
           = bootstrap_flash
           = yield

--- a/spec/features/idea/show.html.haml_spec.rb
+++ b/spec/features/idea/show.html.haml_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "When not signed in" do
+  it "the Idea page should show all related keywords in the sidebar" do
+    idea = Idea.create(name:"Hello Idea", desc:"Great idea")
+    idea.keywords.create name:"Project", concrete:false
+    Keyword.create name:"Mobile", concrete:false
+    visit idea_path(idea)
+    expect(page).to have_content("Project")
+    expect(page).to have_no_content("Mobile")
+  end
+end

--- a/spec/features/keyword/index.html.haml_spec.rb
+++ b/spec/features/keyword/index.html.haml_spec.rb
@@ -5,15 +5,10 @@ describe "When not signed in" do
     @idea = Idea.create(name:"Hello Idea", desc:"Great idea")
   end
 
-  it "the Idea index page should list all the ideas" do
-    visit ideas_path
-    expect(page).to have_content("Hello Idea")
-  end
-
-  it "the Idea index page should show all keywords in the sidebar" do
+  it "the Keyword index page should show all keywords in the sidebar" do
     @idea.keywords.create name:"Project", concrete:false
     Keyword.create name:"Mobile", concrete:false
-    visit ideas_path
+    visit keywords_path      
     expect(page).to have_content("Project")
     expect(page).to have_content("Mobile")
   end


### PR DESCRIPTION
List keywords on the left sidebar except on page showing only one idea where only the attached keywords are shown. Testing that the right keywords on idea-index, keyword-index, and single idea pages are showing. Resolves #30.
