### PR TITLE
Make URLs clickable inside the description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'haml-rails'
 
 gem 'twitter-bootstrap-rails'
 
+gem 'rails_autolink'
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false
@@ -68,3 +70,5 @@ end
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ group :doc do
   gem 'sdoc', require: false
 end
 
+group :test do
+  gem 'fabrication-rails'
+end
 group :development do
   gem 'pry-rails'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,10 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.3)
     execjs (2.0.2)
+    fabrication (2.9.6)
+    fabrication-rails (0.0.1)
+      fabrication
+      railties (>= 3.0)
     ffi (1.9.3)
     formatador (0.2.4)
     guard (2.3.0)
@@ -219,6 +223,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.0.0)
   coveralls
+  fabrication-rails
   guard-bundler
   guard-livereload
   guard-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
+    rails_autolink (1.1.5)
+      rails (> 3.1)
     rails_serve_static_assets (0.0.2)
     rails_stdout_logging (0.0.3)
     railties (4.0.2)
@@ -228,6 +230,7 @@ DEPENDENCIES
   pry-rails
   rails (= 4.0.2)
   rails_12factor
+  rails_autolink
   rspec-rails
   sass-rails (~> 4.0.0)
   sdoc

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,3 +11,7 @@
  *= require_self
  *= require_tree .
  */
+.well.sidebar-nav {
+  background:white;
+  border:none;
+}

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -42,7 +42,7 @@ class IdeasController < ApplicationController
         keyword_ids.include? k.id.to_s
         end
       @idea.keywords << keywords
-      redirect_to :back
+      redirect_to @idea
 
     else
       respond_to do |format|

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -1,3 +1,5 @@
+require 'rails_autolink'
+
 class IdeasController < ApplicationController
 		
   before_action :set_idea, only: [:show, :edit, :update, :destroy]

--- a/app/views/ideas/index.html.haml
+++ b/app/views/ideas/index.html.haml
@@ -26,7 +26,7 @@
             = link_to t('.edit', :default => t("helpers.links.edit")), edit_idea_path(idea), :class => 'btn btn-mini'
             = link_to t('.destroy', :default => t("helpers.links.destroy")), idea_path(idea), :method => :delete, :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-mini btn-danger'
 
-= link_to t('.new', :default => t("helpers.links.new")), new_idea_path, :class => 'btn btn-primary'
+-# = link_to t('.new', :default => t("helpers.links.new")), new_idea_path, :class => 'btn btn-primary'
 
 
 

--- a/app/views/ideas/show.html.haml
+++ b/app/views/ideas/show.html.haml
@@ -1,3 +1,4 @@
+
 - model_class = Idea
 .page-header
   %h1=t '.title', :default => model_class.model_name.human.titleize
@@ -10,7 +11,7 @@
   %strong= model_class.human_attribute_name(:desc) + ':'
   %br
   -# TODO: textarea formatting now includes returns
-  = simple_format @idea.desc
+  = simple_format (auto_link (@idea.desc))
 
 %h3 Related Keywords:
 %ul

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -33,6 +33,8 @@
             %ul.nav
               %li= link_to "Ideas", ideas_path
               %li= link_to "Keywords", keywords_path
+              %li= link_to "New Idea", new_idea_path
+
 
     .container-fluid
 
@@ -42,10 +44,12 @@
             %ul.nav.nav-list
               %li.nav-header Keywords
               - @words.each do |keyword|                                     
-                %li= link_to keyword.name, keyword_path(keyword)
-        .span9
+                %li= link_to keyword.name, keyword_path(keyword)            
+        .span6
           = bootstrap_flash
           = yield
+        .span3
+          .well.sidebar-nav
     
       %footer
         %p &copy; tktl-appideas

--- a/spec/fabricators/idea_fabricator.rb
+++ b/spec/fabricators/idea_fabricator.rb
@@ -1,0 +1,8 @@
+Fabricator(:idea) do
+  name "Hello Idea"
+  desc "Bacon ipsum dolor sit amet chuck biltong cow, sirloin meatball doner flank pork loin rump kevin. Ham shank shoulder porchetta. Ground round kielbasa landjaeger, fatback jowl tail hamburger beef ribs. Frankfurter pork belly biltong drumstick. Ham hock sausage beef pork loin swine ground round kevin, flank beef ribs short ribs shank.
+  
+  Drumstick strip steak swine shankle pastrami. Ham andouille fatback, pork loin biltong t-bone pork belly ball tip turducken corned beef rump sausage beef meatball swine. Shoulder ground round ball tip pork chop fatback kielbasa venison tail jowl. Ground round ribeye turkey jerky tri-tip, hamburger spare ribs sausage chuck jowl pork chop tongue kevin sirloin andouille. Short loin sausage bacon, kielbasa pork loin pancetta shankle. Cow tongue sirloin flank leberkas, tri-tip jowl tenderloin ribeye pork loin beef sausage. Short loin ham hock short ribs shankle, jerky kevin pork belly bacon filet mignon ball tip meatloaf pork capicola beef ribs turducken.
+  
+  Pork belly pig shankle jowl ribeye short ribs filet mignon drumstick tenderloin meatball pork andouille ball tip ham hock. Pork belly pork shankle turkey chuck. T-bone capicola brisket chicken. Pancetta pork loin doner ground round pork spare ribs sirloin."
+end

--- a/spec/models/idea_spec.rb
+++ b/spec/models/idea_spec.rb
@@ -1,12 +1,20 @@
 require 'spec_helper'
 
 describe Idea do
+  let(:idea) { Fabricate(:idea) }
+
   describe "that has been created with a keyword" do
-    it "should provide a method to list all its keywords" do
-    end
   end
+
+  it "should provide a method to list all its keywords" do
+    idea.respond_to?(:keywords).should be true
+  end
+
   it "should have a method hello" do
-    idea = Idea.new
-    idea.respond_to?(:hello).should == true
+    idea.respond_to?(:hello).should be true
+  end
+
+  it "should have a description field" do
+    idea.desc.include?("Bacon").should be true
   end
 end


### PR DESCRIPTION
Belongs to #39 -  Uses rails_autolink. Makes URLs clickable and opens new web page. Email addresses open default email app.
 Changes to be committed:
